### PR TITLE
add downscale factor to run_palom()

### DIFF
--- a/palom/cli/schema/svs-config-schema.yml
+++ b/palom/cli/schema/svs-config-schema.yml
@@ -9,6 +9,10 @@ output full path: include('output format')
 pixel size: num(required=False)
 
 # [optional]
+# Number indicating downscale factor between levels in the output pyramid
+pyramid downscale factor: int(required=False, min=2, max=32)
+
+# [optional]
 # FOR DEV USE ONLY; Pyramid level to process, 0 is the lowest level pyramid
 pyramid level: num(required=False)
 

--- a/palom/cli/svs.py
+++ b/palom/cli/svs.py
@@ -177,7 +177,8 @@ def run_palom(
     channel_names,
     output_path,
     qc_path,
-    level
+    level,
+    downscale_factor = 4
 ):
     ref_reader = reader.SvsReader(img_paths[0])
     ref_color_proc = color.PyramidHaxProcessor(ref_reader.pyramid)
@@ -240,7 +241,8 @@ def run_palom(
         pyramid.normalize_mosaics(mosaics),
         output_path,
         pixel_size=pixel_size,
-        channel_names=channel_names
+        channel_names=channel_names,
+        downscale_factor=downscale_factor
     )
     return 0
 

--- a/palom/cli/svs.py
+++ b/palom/cli/svs.py
@@ -122,6 +122,10 @@ def run(args):
         logger.info(f"Using pixel size defined in configuration YAML file: {pixel_size} µm/pixel")
     else: pixel_size = None
 
+    DOWNSCALE_FACTOR = 4
+    if 'pyramid downscale factor' in config:
+        DOWNSCALE_FACTOR = config['pyramid downscale factor']
+
     images = get_image_list(config)
     
     image_paths = [
@@ -158,7 +162,8 @@ def run(args):
         channel_names=channel_names,
         output_path=output_path,
         qc_path=qc_path,
-        level=LEVEL
+        level=LEVEL,
+        downscale_factor=DOWNSCALE_FACTOR
     )
 
     logger.info(f"Finishing {config_file.name}")    
@@ -178,7 +183,7 @@ def run_palom(
     output_path,
     qc_path,
     level,
-    downscale_factor = 4
+    downscale_factor
 ):
     ref_reader = reader.SvsReader(img_paths[0])
     ref_color_proc = color.PyramidHaxProcessor(ref_reader.pyramid)


### PR DESCRIPTION
This PR adds the downscale_factor parameter from `write_pyramid` to be passable from `run_palom()` in `svs.py`. This would be super helpful for the Galaxy implementation of PALOM, which calls run_palom() directly, but needs to be able to change the pyramid scaling and provide it as a user argument. Please let me know if you have questions/concerns. Thank you! 